### PR TITLE
SECURITY bug fix

### DIFF
--- a/envelope/tests/views.py
+++ b/envelope/tests/views.py
@@ -3,6 +3,7 @@ Unit tests for ``django-envelope`` views.
 """
 
 from django.conf import settings
+from django.contrib.auth import logout
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.test import TestCase
@@ -51,6 +52,11 @@ class ContactViewTestCase(TestCase):
         response = self.client.get(self.url)
         self.assertContains(response, 'value="test (John Doe)"')
         self.assertContains(response, 'value="test@example.org"')
+
+        self.client.logout()
+        response = self.client.get(self.url)
+        self.assertNotContains(response, 'value="test (John Doe)"')
+        self.assertNotContains(response, 'value="test@example.org"')
 
     def test_prefilled_form_no_full_name(self):
         u"""

--- a/envelope/views.py
+++ b/envelope/views.py
@@ -67,7 +67,7 @@ class ContactView(FormView):
         u"""
         Automatically fills form fields for authenticated users.
         """
-        initial = super(ContactView, self).get_initial()
+        initial = super(ContactView, self).get_initial().copy()
         user = self.request.user
         if user.is_authenticated():
             # the user might not have a full name, depends on the registration


### PR DESCRIPTION
With current implementation user data is leaking. If django-envelope prefills form, all non-logged in users see pre-filled data.
