### PR TITLE
Templates in tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include LICENSE
 include README.rst
 include MANIFEST.in
 recursive-include envelope/templates *
+recursive-include envelope/tests/templates *
 recursive-include envelope/locale *

--- a/envelope/tests/views.py
+++ b/envelope/tests/views.py
@@ -2,10 +2,13 @@ u"""
 Unit tests for ``django-envelope`` views.
 """
 
+import os
+
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.utils import unittest
 from django.utils.translation import ugettext_lazy as _
 
@@ -17,6 +20,11 @@ except ImportError:
 from envelope import signals
 
 
+test_templates = (
+    os.path.join(os.path.dirname(__file__), 'templates'),
+    os.path.join(os.path.dirname(__file__), '../templates'),
+)
+@override_settings(TEMPLATE_DIRS=test_templates)
 class ContactViewTestCase(TestCase):
     u"""
     Unit tests for contact form view.

--- a/runtests.py
+++ b/runtests.py
@@ -33,9 +33,6 @@ if not settings.configured:
         },
         INSTALLED_APPS = INSTALLED_APPS,
         SITE_ID = 1,
-        TEMPLATE_DIRS = (
-            make_absolute_path('envelope/tests/templates'),
-        ),
         ROOT_URLCONF = 'envelope.tests.urls',
         TEST_RUNNER = 'django_nose.NoseTestSuiteRunner',
         NOSE_ARGS = ['--stop'],


### PR DESCRIPTION
1. You forgot to include test templates in distribution (MANIFEST.in lacks a proper line)
2. But even if you included them, tests would fail if run via `$ ./manage.py test` together with other apps. The reason is lack of `layout.html` template, caused by template loader not seeking in envelope/tests/templates.
3. But even if you patch `TEMPLATE_DIRS` in tests (not in runtests.py configuration), tests can also fail. In my custom `contact.html` template there was some url reversion, and it raises error since no such url-name was in test urls. Remedy: use app-bundled templates.

All those problems are resolved in this patch.
