### PR TITLE
Add mock to tests_requirements.txt

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 coverage==3.7.1
 tox==1.9.2
+mock==1.0.1


### PR DESCRIPTION
Test fails with `ImportError: No module named mock` and succeeds after `pip install mock`
