### PR TITLE
Changed url patterns to be a list of django.conf.urls.url()

### DIFF
--- a/envelope/templatetags/envelope_tags.py
+++ b/envelope/templatetags/envelope_tags.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+from django.utils.safestring import mark_safe
 
 """
 Template tags related to the contact form.
@@ -44,4 +45,4 @@ def antispam_fields():
     if honeypot:
         t = template.Template('{% load honeypot %}{% render_honeypot_field %}')
         content += t.render(template.Context({}))
-    return content
+    return mark_safe(content)

--- a/envelope/urls.py
+++ b/envelope/urls.py
@@ -10,6 +10,6 @@ except ImportError:  # pragma: no cover
 from envelope.views import ContactView
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', ContactView.as_view(), name='envelope-contact'),
-)
+]


### PR DESCRIPTION
As url patters will be deprecated in Django 1.10. Not sure if this will break Django <1.6 compatibility or not.

Currently while using this app Django throws a warning:

```
.virtualenvs/p2p/local/lib/python2.7/site-packages/envelope/urls.py:14: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  url(r'^$', ContactView.as_view(), name='envelope-contact'),
```
