### PR TITLE
Django 1.10 compatibility (Django 2.0 depreciation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyc
 .project
 .pydevproject
+.idea/
 .settings
 dist/
 build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,13 @@ env:
   - TOXENV=py34-dj19
   - TOXENV=py34-dj110
   - TOXENV=py34-dj111
+  - TOXENV=py34-dj20
   - TOXENV=py35-dj19
   - TOXENV=py35-dj110
   - TOXENV=py35-dj111
+  - TOXENV=py35-dj20
   - TOXENV=py36-dj111
+  - TOXENV=py36-dj20
   - TOXENV=coverage
 matrix:
   exclude:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+trunk
+-----
+
+ - Django 1.10 compatibility (Django 2.0 depreciation)
+
 1.3.0
 -----
 

--- a/envelope/views.py
+++ b/envelope/views.py
@@ -73,7 +73,7 @@ class ContactView(FormView):
         """
         initial = super(ContactView, self).get_initial().copy()
         user = self.request.user
-        if user.is_authenticated():
+        if (callable(user.is_authenticated) and user.is_authenticated()) or user.is_authenticated:
             # the user might not have a full name set in the model
             if user.get_full_name():
                 sender = '%s (%s)' % (user.get_username(), user.get_full_name())

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -10,7 +10,12 @@ import unittest
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+
+try:
+    from django.core.urlresolvers import reverse
+except ImportError:
+    from django.urls import reverse
+
 from django.test import TestCase
 
 try:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27-dj{18,19,110,111}, py34-dj{18,19,110,111}, py35-dj{19,110,111}, py36-dj111, coverage
+    py27-dj{18,19,110,111}, py34-dj{18,19,110,111,20}, py35-dj{19,110,111,20}, py36-dj{111,20}, coverage
 
 [testenv]
 basepython =
@@ -15,6 +15,7 @@ deps=
     dj19: Django>=1.9,<1.10
     dj110: Django>=1.10,<1.11
     dj111: Django>=1.11,<2.0
+    dj20: Django>=2.0,<2.1
     py27: mock==2.0.0
 commands=
     make test


### PR DESCRIPTION
Django 1.9 & 1.10 are already depreciated, 1.8 will end its life in April 2018, so shortly this change could be removed in favour os simple property checking.

But if you would like to remove support for everything earlier than 1.11, than this is not needed, just simple change to test for property instead calling method.